### PR TITLE
flower asterisk (aka eight-pointed)

### DIFF
--- a/font-src/glyphs/symbol/punctuation/asterisk.ptl
+++ b/font-src/glyphs/symbol/punctuation/asterisk.ptl
@@ -20,6 +20,7 @@ glyph-block Symbol-Punctuation-Asterisk : begin
 		list { 6  1.2   0    0.4   Stroke          } { 'asterisk'       'dualAsterisk'  'asterism' } { 'hexHigh'       'hexST'       'hexSMid'        ''       'hexSB'       }
 		list { 5  1.2   1    0.4   Stroke          } { 'asterisk'       'dualAsterisk'  'asterism' } { 'turnPentaHigh' 'turnPentaST' 'turnPentaSMid'  ''       'turnPentaSB' }
 		list { 6  1.2   0.5  0.4   Stroke          } { 'asterisk'       'dualAsterisk'  'asterism' } { 'turnHexHigh'   'turnHexST'   'turnHexSMid'    ''       'turnHexSB'   }
+		list { 8  1.2   0.5  0.4  [AdviceStroke 3] } { 'asterisk'       'dualAsterisk'  'asterism' } { 'flowerHigh'    'flowerST'    'flowerSMid'     ''       'flowerSB'    }
 		list { 5  1     0    0.4   GeometryStroke  } { 'opAsterisk'     ''              ''         } { ''              ''            'low'            ''       ''            }
 		list { 8  1.2   0.5  0.4  [AdviceStroke 3] } { 'flower'         ''              ''         } { 'high'          'ST'          'sMid'           ''       ''            }
 
@@ -78,6 +79,7 @@ glyph-block Symbol-Punctuation-Asterisk : begin
 	select-variant 'asterisk/slashBot' 0x204E (shapeFrom -- 'asterisk')
 	select-variant 'asterisk/sMid' (shapeFrom -- 'asterisk')
 	select-variant 'asterisk/sMid/ligComment' (shapeFrom -- 'asterisk') (follow -- 'asterisk/sMid')
+	select-variant 'asterisk/flower' (shapeFrom -- 'flower') (follow -- 'flower')
 	select-variant 'dualAsterisk' 0x2051 (follow -- 'asterisk/sMid')
 	select-variant 'flower' 0x2055
 

--- a/params/variants.toml
+++ b/params/variants.toml
@@ -6357,6 +6357,16 @@ selectorAffix."asterisk/sMid" = "turnHex"
 selectorAffix."asterisk/slashBot" = "turnHex"
 selectorAffix.flower = ""
 
+[prime.asterisk.variants-buildup.stages.body.flower]
+rank = 5
+groupRank = 3
+descriptionAffix = "eight-pointed shape"
+selectorAffix.asterisk = "flower"
+selectorAffix."asterisk/slashTop" = "flower"
+selectorAffix."asterisk/sMid" = "flower"
+selectorAffix."asterisk/slashBot" = "flower"
+selectorAffix.flower = ""
+
 [prime.asterisk.variants-buildup.stages.position.high]
 rank = 1
 descriptionAffix = "high position"
@@ -6364,6 +6374,7 @@ selectorAffix.asterisk = "high"
 selectorAffix."asterisk/slashTop" = "ST"
 selectorAffix."asterisk/sMid" = "SMid"
 selectorAffix."asterisk/slashBot" = "SB"
+selectorAffix."asterisk/flower" = "high"
 selectorAffix.flower = "high"
 
 [prime.asterisk.variants-buildup.stages.position.mid]
@@ -6373,6 +6384,7 @@ selectorAffix.asterisk = "ST"
 selectorAffix."asterisk/slashTop" = "ST"
 selectorAffix."asterisk/sMid" = "SMid"
 selectorAffix."asterisk/slashBot" = "SB"
+selectorAffix."asterisk/flower" = "ST"
 selectorAffix.flower = "ST"
 
 [prime.asterisk.variants-buildup.stages.position.low]
@@ -6382,6 +6394,7 @@ selectorAffix.asterisk = "SMid"
 selectorAffix."asterisk/slashTop" = "ST"
 selectorAffix."asterisk/sMid" = "SMid"
 selectorAffix."asterisk/slashBot" = "SB"
+selectorAffix."asterisk/flower" = "sMid"
 selectorAffix.flower = "sMid"
 
 


### PR DESCRIPTION
For those, who wanted eight-pointed asterisk aka flower asterisk but doesn't know how:

- apply this changes
- and use like: `asterisk = "flower-low"` in `private-build-plans.toml`

NB, checked only 1 custom variant.
Entirely through github web interface